### PR TITLE
News caching

### DIFF
--- a/pages/news/index.js
+++ b/pages/news/index.js
@@ -196,7 +196,10 @@ export async function getServerSideProps({ res }) {
   const json = JSON.parse(JSON.stringify(resp));
   const data = await json;
 
-  res.setHeader("Cache-Control", "s-maxage=43200, stale-while-revalidate");
+  res.setHeader(
+    "Cache-Control",
+    "maxage=43200, s-maxage=43200, stale-while-revalidate"
+  ); // Vercel Cache (Network)
 
   return { props: { data } };
 }


### PR DESCRIPTION
Ok it is pretty straight forward, `getServerSideProps` gets one parameter the `ctx` (Context) which has one prop `res` the response. We can set the header as we did on the api routes.

Fixes #30